### PR TITLE
chore/fix-svelte-auto-compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@types/node-fetch": "1.6.7",
 		"@types/node": "9.3.0",
 		"@types/passport": "0.4.2",
+		"@types/passport-saml": "0.15.5",
 		"@types/session-file-store": "1.2.0",
 		"tslint": "5.9.1",
 		"typescript": "2.6.2"

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -1,6 +1,6 @@
 import {Request, Response} from 'express'
-import * as svelte from 'ui/svelte'
+import * as template from 'ui/template'
 
 export let index = (req: Request, res: Response) => {
-	res.send(svelte.render('index'))
+	res.send(template.render('index'))
 }

--- a/src/controllers/search.ts
+++ b/src/controllers/search.ts
@@ -1,11 +1,11 @@
 import {Request, Response} from 'express'
-import * as svelte from 'ui/svelte'
 import {User} from 'ui/controllers/user'
+import * as template from 'ui/template'
 
 export let index = (req: Request, res: Response) => {
 	res.send(renderSearch(req.user))
 }
 
 function renderSearch(user: User) {
-	return svelte.render('search', user)
+	return template.render('search', user)
 }

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -1,6 +1,6 @@
-import {Request, Response} from 'express'
-import * as svelte from 'ui/svelte'
 import * as config from 'config'
+import {Request, Response} from 'express'
+import * as template from 'ui/template'
 
 export let signIn = (req: Request, res: Response) => {
 	const sessionDataKey = req.query.sessionDataKey
@@ -13,9 +13,9 @@ export let signIn = (req: Request, res: Response) => {
 	} else {
 		res.send(
 			renderSignIn({
+				authenticationServiceUrl: config.get('authentication.serviceUrl'),
 				loginFailed,
 				sessionDataKey,
-				authenticationServiceUrl: config.get('authentication.serviceUrl'),
 			})
 		)
 	}
@@ -45,9 +45,9 @@ export interface User {
 }
 
 function renderSignIn(props: SignIn) {
-	return svelte.render('sign-in', props)
+	return template.render('sign-in', props)
 }
 
 function renderProfile(props: User) {
-	return svelte.render('profile', props)
+	return template.render('profile', props)
 }

--- a/src/svelte.d.ts
+++ b/src/svelte.d.ts
@@ -1,0 +1,88 @@
+declare module 'svelte' {
+	export interface CompileOptions {
+		format?: ModuleFormat
+		name?: string
+		filename?: string
+		generate?: string
+		globals?: ((id: string) => string) | object
+		amd?: {
+			id?: string
+		}
+
+		outputFilename?: string
+		cssOutputFilename?: string
+
+		dev?: boolean
+		shared?: boolean | string
+		cascade?: boolean
+		hydratable?: boolean
+		legacy?: boolean
+		customElement?: CustomElementOptions | true
+		css?: boolean
+		store?: boolean
+
+		onerror?: (error: Error) => void
+		onwarn?: (warning: Warning) => void
+	}
+
+	export interface CompiledOutput {
+		ast: {
+			html: Node
+		}
+		code: string
+	}
+
+	export interface CustomElementOptions {
+		tag?: string
+		props?: string[]
+	}
+
+	export type ModuleFormat = 'es' | 'amd' | 'cjs' | 'iife' | 'umd' | 'eval'
+
+	interface Node {
+		children: Node[]
+		name: string
+		type: string
+	}
+
+	export interface PreprocessOptions {
+		markup?: (
+			options: {content: string; filename: string}
+		) => {code: string; map?: SourceMap | string}
+		style?: Preprocessor
+		script?: Preprocessor
+		filename?: string
+	}
+
+	export type Preprocessor = (
+		options: {
+			content: string
+			attributes: Record<string, string | boolean>
+			filename?: string
+		}
+	) => {code: string; map?: SourceMap | string}
+
+	export interface SourceMap {
+		file: string
+		sources: string[]
+		sourcesContent: string
+		names: string[]
+		mappings: string[]
+
+		toString(): string
+		toUrl(): string
+	}
+
+	export interface Warning {
+		loc?: {line: number; column: number; pos?: number}
+		pos?: number
+		message: string
+		filename?: string
+		frame?: string
+		toString: () => string
+	}
+
+	export function compile(source: string, opts: CompileOptions): CompiledOutput
+
+	export function preprocess(source: string, handlers: PreprocessOptions): void
+}


### PR DESCRIPTION
This PR:

* Introduces the use of dependency analysis to determine the appropriate sequence when compiling template components.

* Renames the `ui/svelte` module to `ui/template`.

* Adds type definition for the third-party svelte package, at least for the parts of the API that we use, as well as uses the `@types/passport-saml` definition for that package.